### PR TITLE
fix matching the correct struct

### DIFF
--- a/src/database/simple.jl
+++ b/src/database/simple.jl
@@ -189,7 +189,7 @@ begin
         v"0.4.0", v"0.7.0-DEV.797", typemax(VersionNumber)
     ))
 
-    match(ConditionalWhitespace, CSTParser.Generator) do x
+    match(GeneratorWhitespace, CSTParser.Generator) do x
         dep, expr, resolutions, context = x
         ret = ChildReplacementNode(nothing, collect(children(expr)), expr)
         body, fornode, iterand = children(expr)


### PR DESCRIPTION
Since the version requirements are the same, this shouldn't be a function change (except if the reported deprecation message is used somewhere)