### PR TITLE
 work around CSTParser bug with lexical ordering in filter nodes

### DIFF
--- a/src/treewalking.jl
+++ b/src/treewalking.jl
@@ -32,6 +32,9 @@ Base.length(::CSTParser.IDENTIFIER) = 0
 
 children(node::OverlayNode) = node
 
+# CSTParser gives argument in filter in the opposite lexical order,
+# remove this when fixed in CSTParser
+children(filter::EXPR{CSTParser.Filter}) = reverse(filter.args)
 
 function Base.getindex(node::OverlayNode, idx::Integer)
     offset = first(node.fullspan)
@@ -51,7 +54,7 @@ Base.setindex!(o::OverlayNode, x::OverlayNode, idx) = Base.setindex!(o.expr.args
 Base.start(node::OverlayNode) = (start(node.expr), first(node.fullspan))
 function Base.next(node::OverlayNode, state::Tuple{Int, Int})
     idx, offset = state
-    expr, idx = next(node.expr, idx)
+    expr, idx = next(children(node.expr), idx)
     (OverlayNode(node, node.buffer, expr, offset:(offset+expr.fullspan-1), offset - 1 + expr.span), (idx, offset + expr.fullspan))
 end
 Base.done(node::OverlayNode, state::Tuple{Int, Int}) = done(node.expr, state[1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1040,4 +1040,11 @@ julia> f(a::T) where {T} = 1
 f (generic function with 1 method)
 ```
 """
+
+@test text_not_edited("""
+[i for i in 1:2 if all([c for c in a])]
+""")
+
 end
+
+


### PR DESCRIPTION
Pretty ugly, but what can you do...