### PR TITLE
correct extraction of lbrace

### DIFF
--- a/src/database/parametric.jl
+++ b/src/database/parametric.jl
@@ -171,7 +171,7 @@ begin
         end
         nchars_moved = (needs_new_curly ? sum(expr->sum(charwidth, fullspan_text(expr)), children(new_curly)[2:end]) : 0) -
                        (had_curly ? line_pos(call, first(children(call)[2].span)) - (line_pos(curly, first(children(curly)[2].span))) : 0)
-        heuristic_pos = had_curly ? line_pos(curly, first(curly.span)) : line_pos(call, first(children(call)[2].span)-1)
+        heuristic_pos = had_curly ? line_pos(curly, first(children(curly)[4].span)) : line_pos(call, first(children(call)[2].span)-1)
         format_arglist!(new_where, nchars_moved, heuristic_pos)
         # If the parameter list is multi-line, it might need to be indented as well
         if had_curly

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1093,4 +1093,21 @@ end
 [i for i in 1:2 if all([c for c in a])]
 """)
 
+
+@test edit_text("""
+function faem{T<:AbstractFloat}(S::DenseMatrix{T}, mv::Vector{T}, n::Int;
+             maxoutdim::Int=size(X,1)-1,
+             tol::Real=1.0e-6,   # convergence tolerance
+             tot::Integer=1000)  # maximum number of iterations
+    return x
+end
+""")[2] == """
+function faem(S::DenseMatrix{T}, mv::Vector{T}, n::Int;
+             maxoutdim::Int=size(X,1)-1,
+             tol::Real=1.0e-6,   # convergence tolerance
+             tot::Integer=1000) where T<:AbstractFloat  # maximum number of iterations
+    return x
+end
+"""
+
 end # testset


### PR DESCRIPTION
Previously, the linepos of the `Curly` node was used, but it seems we actually want the linepos of the `LBRACE`.

Fixes half of https://github.com/JuliaComputing/FemtoCleaner.jl/issues/59